### PR TITLE
Allow any characters for passwords

### DIFF
--- a/lib/redis-copy/cli.rb
+++ b/lib/redis-copy/cli.rb
@@ -5,7 +5,7 @@ require 'optparse'
 
 module RedisCopy
   class CLI
-    REDIS_URI = (/\A(?:redis:\/\/)?(\w*:\w+@)?([a-z0-9\-.]+)(:[0-9]{1,5})?(\/(?:(?:1[0-5])|[0-9]))?\z/i).freeze
+    REDIS_URI = (/\A(?:redis:\/\/)?(\w*:.+@)?([a-z0-9\-.]+)(:[0-9]{1,5})?(\/(?:(?:1[0-5])|[0-9]))?\z/i).freeze
     DEFAULTS = {
       ui:             :command_line,
       verify:         0,


### PR DESCRIPTION
Redis passwords are not limited to letters, numbers or underscores.
