### PR TITLE
Support rediss:// URIs

### DIFF
--- a/lib/redis-copy.rb
+++ b/lib/redis-copy.rb
@@ -88,7 +88,7 @@ module RedisCopy
 
     def redis_from(connection_string)
       require 'uri'
-      connection_string = "redis://#{connection_string}" unless connection_string.start_with?("redis://")
+      connection_string = "redis://#{connection_string}" unless connection_string.start_with?("redis://", "rediss://")
       uri = URI(connection_string)
       ret = {uri: uri}
 


### PR DESCRIPTION
This prefix is supported by the redis gem, so should work transparently here https://github.com/redis/redis-rb/commit/6208313463c1bde0c40558a5018713d02786505f